### PR TITLE
railtie: allow configuring 'log_controller_parameters' through YAML

### DIFF
--- a/lib/logstasher/railtie.rb
+++ b/lib/logstasher/railtie.rb
@@ -74,5 +74,6 @@ module LogStasher
     config.backtrace = yml_config[:backtrace] if yml_config.key? :backtrace
     config.logger_path = yml_config[:logger_path] if yml_config.key? :logger_path
     config.log_level = yml_config[:log_level] if yml_config.key? :log_level
+    config.log_controller_parameters = yml_config[:log_controller_parameters] if yml_config.key? :log_controller_parameters
   end
 end


### PR DESCRIPTION
Follow-up to:
https://github.com/shadabahmed/logstasher/commit/90203a7e06fbdcd9fa323723e4874bbce90b6254

I think it would be wise to allow configuring this option through the YAML file
because it would be consistent. Right now, users who use the YAML configuration
file and want to configure the `log_controller_parameters` option have to
configure logstasher at two places.