### PR TITLE
active_record/log_subscriber: preserve db_runtime

### DIFF
--- a/lib/logstasher/active_record/log_subscriber.rb
+++ b/lib/logstasher/active_record/log_subscriber.rb
@@ -22,6 +22,7 @@ module LogStasher
       private
 
       def logstash_event(event)
+        self.class.runtime += event.duration
         data = event.payload
 
         return if 'SCHEMA' == data[:name]


### PR DESCRIPTION
Fixes https://github.com/shadabahmed/logstasher/issues/137
(suppress_app_log: true prevent DB timing to be emited)

LogStasher removes all default Rails loggers. `ActiveRecord::LogSubscriber` was
used to set [`db_runtime`][1] for the `ActiveSupport::Notifications`
instrumentation API. Our subclass never populates it, which causes the bug:
`db_runtime` is always 0.

[1]: https://guides.rubyonrails.org/active_support_instrumentation.html#process-action-action-controller